### PR TITLE
allow insert objects into cells

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2683,8 +2683,8 @@ if (typeof Slick === "undefined") {
       stringArray.push("<div class='" + cellCss + (addlCssClasses ? ' ' + addlCssClasses : '') + "' " + toolTip + ">");
 
       // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
-      if (item) {
-        stringArray.push(Object.prototype.toString.call(formatterResult)  !== '[object Object]' ? formatterResult : formatterResult.text);
+        if (item) {
+            stringArray.push(formatterResult);
       }
 
       stringArray.push("</div>");
@@ -3378,7 +3378,25 @@ if (typeof Slick === "undefined") {
       var x = document.createElement("div"),
         xRight = document.createElement("div");
 
+      var innerHtml = "";
+      var objectList = [];
+      for (var i = 0; i < stringArrayL.length; i++) {
+          if (typeof stringArrayL[i] !== "string") {
+              objectList.push(stringArrayL[i]);
+              stringArrayL[i] = "<div class='slick-object-container'></div>";
+          }
+      }
+
       x.innerHTML = stringArrayL.join("");
+      var containersHtml = x.getElementsByClassName('slick-object-container');
+      for (var i = 0; i < objectList.length; i++) {
+          containersHtml[i].parentElement.append(objectList[i]);
+      }
+
+      for (var i = 0; i < objectList.length; i++) {
+          containersHtml[0].remove();
+      }
+
       xRight.innerHTML = stringArrayR.join("");
 
       for (var i = 0, ii = rows.length; i < ii; i++) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3378,26 +3378,43 @@ if (typeof Slick === "undefined") {
       var x = document.createElement("div"),
         xRight = document.createElement("div");
 
-      var innerHtml = "";
-      var objectList = [];
-      for (var i = 0; i < stringArrayL.length; i++) {
-          if (typeof stringArrayL[i] !== "string") {
-              objectList.push(stringArrayL[i]);
-              stringArrayL[i] = "<div class='slick-object-container'></div>";
-          }
-      }
+        //insert objects into left side
+        var objectListL = [];
+        for (var i = 0; i < stringArrayL.length; i++) {
+            if (typeof stringArrayL[i] !== "string") {
+                objectListL.push(stringArrayL[i]);
+                stringArrayL[i] = "<div class='slick-object-container'></div>";
+            }
+        }
 
-      x.innerHTML = stringArrayL.join("");
-      var containersHtml = x.getElementsByClassName('slick-object-container');
-      for (var i = 0; i < objectList.length; i++) {
-          containersHtml[i].parentElement.append(objectList[i]);
-      }
+        x.innerHTML = stringArrayL.join("");
+        var containersHtml = x.getElementsByClassName('slick-object-container');
+        for (var i = 0; i < objectListL.length; i++) {
+            containersHtml[i].parentElement.append(objectListL[i]);
+        }
 
-      for (var i = 0; i < objectList.length; i++) {
-          containersHtml[0].remove();
-      }
+        for (var i = 0; i < objectListL.length; i++) {
+            containersHtml[0].remove();
+        }
 
-      xRight.innerHTML = stringArrayR.join("");
+        //insert objects into right side
+        var objectListR = [];
+        for (var i = 0; i < stringArrayR.length; i++) {
+            if (typeof stringArrayR[i] !== "string") {
+                objectListR.push(stringArrayR[i]);
+                stringArrayR[i] = "<div class='slick-object-container'></div>";
+            }
+        }
+
+        xRight.innerHTML = stringArrayR.join("");
+        containersHtml = xRight.getElementsByClassName('slick-object-container');
+        for (var i = 0; i < objectListR.length; i++) {
+            containersHtml[i].parentElement.append(objectListR[i]);
+        }
+
+        for (var i = 0; i < objectListR.length; i++) {
+            containersHtml[0].remove();
+        }
 
       for (var i = 0, ii = rows.length; i < ii; i++) {
         if (( hasFrozenRows ) && ( rows[i] >= actualFrozenRow )) {


### PR DESCRIPTION
Cells were previously parsed to html, this change allows DOM objects to be passed through.

- removed the parse to string of the cell.
- before creating the DOM I loop through the items, when an object is found I save it to a list and replace it in the original array with a temporary container, then after creating the DOM I insert my objects in the containers's parent and remove the containers... maybe "placeholder" would be a better name?